### PR TITLE
Feature - change getter for Boolean type to isFieldName();

### DIFF
--- a/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
+++ b/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
@@ -51,6 +51,20 @@ public class ${prefWrapperClassName} extends SharedPreferencesWrapper {
     // region ${pref.fieldName?cap_first}
     //================================================================================
 
+    <#if pref.type == "BOOLEAN">
+    <#if pref.comment??>
+    /**
+     * ${pref.comment?trim}
+     */
+    </#if><#t>
+    <#if !disableNullable && pref.defaultValue == "null">
+    @Nullable
+    </#if><#t>
+    public ${pref.type.simpleName} get${pref.fieldName?cap_first}() {
+        return is${pref.fieldName?cap_first}();
+    }
+    </#if>
+
     <#if pref.comment??>
     /**
      * ${pref.comment?trim}

--- a/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
+++ b/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
@@ -59,7 +59,7 @@ public class ${prefWrapperClassName} extends SharedPreferencesWrapper {
     <#if !disableNullable && pref.defaultValue == "null">
     @Nullable
     </#if><#t>
-    public ${pref.type.simpleName} get${pref.fieldName?cap_first}() {
+    public ${pref.type.simpleName} <#if pref.type == "BOOLEAN">is<#else>get</#if>${pref.fieldName?cap_first}() {
         if (!contains("${pref.prefName}")) return ${pref.defaultValue};
         return get${pref.type.methodName}("${pref.prefName}", ${pref.type.defaultValue});
     }

--- a/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
+++ b/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
@@ -62,8 +62,7 @@ public class ${prefWrapperClassName} extends SharedPreferencesWrapper {
     </#if><#t>
     @Deprecated
     public ${pref.type.simpleName} get${pref.fieldName?cap_first}() {
-        if (!contains("${pref.prefName}")) return ${pref.defaultValue};
-        return get${pref.type.methodName}("${pref.prefName}", ${pref.type.defaultValue});
+        return is${pref.fieldName?cap_first}();
     }
     </#if>
 

--- a/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
+++ b/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
@@ -51,6 +51,22 @@ public class ${prefWrapperClassName} extends SharedPreferencesWrapper {
     // region ${pref.fieldName?cap_first}
     //================================================================================
 
+    <#if pref.type == "BOOLEAN">
+    <#if pref.comment??>
+    /**
+     * ${pref.comment?trim}
+     */
+    </#if><#t>
+    <#if !disableNullable && pref.defaultValue == "null">
+    @Nullable
+    </#if><#t>
+    @Deprecated
+    public ${pref.type.simpleName} get${pref.fieldName?cap_first}() {
+        if (!contains("${pref.prefName}")) return ${pref.defaultValue};
+        return get${pref.type.methodName}("${pref.prefName}", ${pref.type.defaultValue});
+    }
+    </#if>
+
     <#if pref.comment??>
     /**
      * ${pref.comment?trim}

--- a/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
+++ b/prefs-compiler/src/main/resources/org/jraf/android/prefs/compiler/prefwrapper.ftl
@@ -51,21 +51,6 @@ public class ${prefWrapperClassName} extends SharedPreferencesWrapper {
     // region ${pref.fieldName?cap_first}
     //================================================================================
 
-    <#if pref.type == "BOOLEAN">
-    <#if pref.comment??>
-    /**
-     * ${pref.comment?trim}
-     */
-    </#if><#t>
-    <#if !disableNullable && pref.defaultValue == "null">
-    @Nullable
-    </#if><#t>
-    @Deprecated
-    public ${pref.type.simpleName} get${pref.fieldName?cap_first}() {
-        return is${pref.fieldName?cap_first}();
-    }
-    </#if>
-
     <#if pref.comment??>
     /**
      * ${pref.comment?trim}

--- a/sample/src/main/java/org/jraf/android/prefs/sample/app/MainActivity.java
+++ b/sample/src/main/java/org/jraf/android/prefs/sample/app/MainActivity.java
@@ -43,7 +43,6 @@ public class MainActivity extends Activity {
         mainPrefs.putAge(null);
         Log.d(TAG, "login=" + mainPrefs.getLogin());
         Log.d(TAG, "age=" + mainPrefs.getAge());
-        Log.d(TAG, "premium=" + mainPrefs.getPremium());
         Log.d(TAG, "premium=" + mainPrefs.isPremium());
         Log.d(TAG, "mainPrefs=" + mainPrefs.getAll());
 

--- a/sample/src/main/java/org/jraf/android/prefs/sample/app/MainActivity.java
+++ b/sample/src/main/java/org/jraf/android/prefs/sample/app/MainActivity.java
@@ -43,6 +43,7 @@ public class MainActivity extends Activity {
         mainPrefs.putAge(null);
         Log.d(TAG, "login=" + mainPrefs.getLogin());
         Log.d(TAG, "age=" + mainPrefs.getAge());
+        Log.d(TAG, "premium=" + mainPrefs.getPremium());
         Log.d(TAG, "premium=" + mainPrefs.isPremium());
         Log.d(TAG, "mainPrefs=" + mainPrefs.getAll());
 

--- a/sample/src/main/java/org/jraf/android/prefs/sample/app/MainActivity.java
+++ b/sample/src/main/java/org/jraf/android/prefs/sample/app/MainActivity.java
@@ -43,6 +43,7 @@ public class MainActivity extends Activity {
         mainPrefs.putAge(null);
         Log.d(TAG, "login=" + mainPrefs.getLogin());
         Log.d(TAG, "age=" + mainPrefs.getAge());
+        Log.d(TAG, "premium=" + mainPrefs.isPremium());
         Log.d(TAG, "mainPrefs=" + mainPrefs.getAll());
 
         SettingsPrefs settingsPrefs = SettingsPrefs.get(this);

--- a/sample/src/main/java/org/jraf/android/prefs/sample/prefs/Main.java
+++ b/sample/src/main/java/org/jraf/android/prefs/sample/prefs/Main.java
@@ -47,7 +47,7 @@ public class Main {
     String password;
 
     @DefaultBoolean(false)
-    Boolean isPremium;
+    Boolean premium;
 
     @Name(PREF_AGE)
     Integer age;


### PR DESCRIPTION
Change getter to `Boolean` fields to match the [JavaBean Specification (8.3.2)](http://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html)

> **8.3.2 Boolean properties**
> In addition, for boolean properties, we allow a getter method to match the pattern:
> `public boolean is<PropertyName>();`
> This “is<PropertyName>” method may be provided instead of a “get<PropertyName>” method, or it may be provided in addition to a “get<PropertyName>” method.
> In either case, if the “is<PropertyName>” method is present for a boolean property then we will use the “is<PropertyName>” method to read the property value.
> An example boolean property might be:
> `public boolean isMarsupial();`
> `public void setMarsupial(boolean m);`
